### PR TITLE
Add container security scanning

### DIFF
--- a/.github/workflows/container-scan-trivy.yml
+++ b/.github/workflows/container-scan-trivy.yml
@@ -1,0 +1,40 @@
+---
+name: trivy-container-scan
+
+# Run for all pushes to main and pull requests when Go or YAML files change
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '15 15 * * 2'
+  pull_request:
+
+jobs:
+
+  scan-trivy-1:
+    name: sec-scan-trivy-1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: localbuild/sec-scan-trivy:latest
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: localbuild/sec-scan-trivy:latest
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+


### PR DESCRIPTION
This adds a workflow that runs Trivy [1] on all Dockerfiles in the repository.

The intention is to verify that Pull Requests don't introduce security vulnerabilities.

The workflow will also run on a specified cadence (Tuesdays at 15:15 UTC). Which
will allow us to discover new package-level vulnerabilities in the container(s).

Note that scanning container images in clusters will be handled elsewhere and not
as part of this PR.

[1] https://aquasecurity.github.io/trivy/
